### PR TITLE
feat(gitutil): support filter=encrypten in .gitattributes

### DIFF
--- a/internal/gitutil/attributes.go
+++ b/internal/gitutil/attributes.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 )
 
-// EncryptedFileEntry represents a file with a git-crypt filter attribute.
+// EncryptedFileEntry represents a file with a git-crypt or encrypten filter attribute.
 type EncryptedFileEntry struct {
 	Path    string
 	KeyName string
 }
 
-// ListEncryptedFiles returns files that have filter=git-crypt set in .gitattributes.
+// ListEncryptedFiles returns files that have filter=git-crypt or filter=encrypten set in .gitattributes.
 // It uses git check-attr to let git handle attribute resolution (including
 // nested .gitattributes and glob patterns).
 func ListEncryptedFiles(dir string) ([]EncryptedFileEntry, error) {
@@ -62,14 +62,16 @@ func parseCheckAttrOutput(data []byte) []EncryptedFileEntry {
 	return entries
 }
 
-// parseFilterValue checks if a filter attribute value indicates git-crypt
-// encryption and returns the corresponding entry.
+// parseFilterValue checks if a filter attribute value indicates git-crypt or
+// encrypten encryption and returns the corresponding entry.
 func parseFilterValue(path, value string) (EncryptedFileEntry, bool) {
-	if value == "git-crypt" {
-		return EncryptedFileEntry{Path: path, KeyName: "default"}, true
-	}
-	if keyName, ok := strings.CutPrefix(value, "git-crypt-"); ok {
-		return EncryptedFileEntry{Path: path, KeyName: keyName}, true
+	for _, prefix := range []string{"git-crypt", "encrypten"} {
+		if value == prefix {
+			return EncryptedFileEntry{Path: path, KeyName: "default"}, true
+		}
+		if keyName, ok := strings.CutPrefix(value, prefix+"-"); ok {
+			return EncryptedFileEntry{Path: path, KeyName: keyName}, true
+		}
 	}
 	return EncryptedFileEntry{}, false
 }

--- a/internal/gitutil/attributes_test.go
+++ b/internal/gitutil/attributes_test.go
@@ -106,6 +106,57 @@ func TestListEncryptedFilesGlob(t *testing.T) {
 	}
 }
 
+func TestListEncryptedFilesEncryptenFilter(t *testing.T) {
+	dir := initTestRepo(t)
+
+	writeFile(t, dir, ".gitattributes", "secret.txt filter=encrypten diff=encrypten\n")
+	writeFile(t, dir, "secret.txt", "secret data")
+	writeFile(t, dir, "plain.txt", "plain data")
+
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "add files")
+
+	entries, err := gitutil.ListEncryptedFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Path != "secret.txt" {
+		t.Errorf("Path = %q, want %q", entries[0].Path, "secret.txt")
+	}
+	if entries[0].KeyName != "default" {
+		t.Errorf("KeyName = %q, want %q", entries[0].KeyName, "default")
+	}
+}
+
+func TestListEncryptedFilesEncryptenNamedKey(t *testing.T) {
+	dir := initTestRepo(t)
+
+	writeFile(t, dir, ".gitattributes", "secret.txt filter=encrypten-mykey diff=encrypten-mykey\n")
+	writeFile(t, dir, "secret.txt", "named key secret")
+
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "add named key file")
+
+	entries, err := gitutil.ListEncryptedFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if entries[0].Path != "secret.txt" {
+		t.Errorf("Path = %q, want %q", entries[0].Path, "secret.txt")
+	}
+	if entries[0].KeyName != "mykey" {
+		t.Errorf("KeyName = %q, want %q", entries[0].KeyName, "mykey")
+	}
+}
+
 func TestListEncryptedFilesNamedKey(t *testing.T) {
 	dir := initTestRepo(t)
 

--- a/internal/gitutil/config.go
+++ b/internal/gitutil/config.go
@@ -59,13 +59,20 @@ func gitConfigGet(dir string, key string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// SetFilter configures the git-crypt filter (smudge, clean, required).
+// filterSections lists the filter name prefixes to configure.
+// Both git-crypt (for backward compatibility) and encrypten are registered.
+var filterSections = []string{"git-crypt", "encrypten"}
+
+// SetFilter configures the git-crypt and encrypten filters (smudge, clean, required).
 // It is idempotent — values that already match are skipped.
 func SetFilter(dir string) error {
-	pairs := []struct{ key, val string }{
-		{"filter.git-crypt.smudge", filterSmudge},
-		{"filter.git-crypt.clean", filterClean},
-		{"filter.git-crypt.required", filterReqd},
+	var pairs []struct{ key, val string }
+	for _, section := range filterSections {
+		pairs = append(pairs,
+			struct{ key, val string }{"filter." + section + ".smudge", filterSmudge},
+			struct{ key, val string }{"filter." + section + ".clean", filterClean},
+			struct{ key, val string }{"filter." + section + ".required", filterReqd},
+		)
 	}
 	for _, p := range pairs {
 		got, err := gitConfigGet(dir, p.key)
@@ -79,26 +86,35 @@ func SetFilter(dir string) error {
 	return nil
 }
 
-// SetDiffTextconv configures the git-crypt diff textconv driver.
-// It is idempotent — the value is skipped if it already matches.
+// SetDiffTextconv configures the git-crypt and encrypten diff textconv drivers.
+// It is idempotent — values that already match are skipped.
 func SetDiffTextconv(dir string) error {
-	got, err := gitConfigGet(dir, "diff.git-crypt.textconv")
-	if err == nil && got == diffTextconv {
-		return nil
+	for _, section := range filterSections {
+		key := "diff." + section + ".textconv"
+		got, err := gitConfigGet(dir, key)
+		if err == nil && got == diffTextconv {
+			continue
+		}
+		if err := gitConfig(dir, key, diffTextconv); err != nil {
+			return err
+		}
 	}
-	return gitConfig(dir, "diff.git-crypt.textconv", diffTextconv)
+	return nil
 }
 
-// UnsetFilter removes both filter.git-crypt and diff.git-crypt sections.
+// UnsetFilter removes filter and diff sections for both git-crypt and encrypten.
 // It is idempotent — missing sections are silently ignored.
 func UnsetFilter(dir string) error {
-	for _, section := range []string{"filter.git-crypt", "diff.git-crypt"} {
-		if err := gitConfig(dir, "--remove-section", section); err != nil {
-			// Exit code 128 means the section doesn't exist; ignore it.
-			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
-				continue
+	for _, name := range filterSections {
+		for _, kind := range []string{"filter", "diff"} {
+			section := kind + "." + name
+			if err := gitConfig(dir, "--remove-section", section); err != nil {
+				// Exit code 128 means the section doesn't exist; ignore it.
+				if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
+					continue
+				}
+				return err
 			}
-			return err
 		}
 	}
 	return nil
@@ -114,60 +130,76 @@ func EnableWorktreeConfig(dir string) error {
 	return gitConfig(dir, "extensions.worktreeConfig", "true")
 }
 
-// SetFilterWorktree sets filter.git-crypt and diff.git-crypt using --worktree scope.
+// SetFilterWorktree sets filter and diff config for both git-crypt and encrypten
+// using --worktree scope.
 func SetFilterWorktree(dir, smudge, clean, required string) error {
 	if err := EnableWorktreeConfig(dir); err != nil {
 		return fmt.Errorf("enabling worktree config: %w", err)
 	}
-	if err := gitConfig(dir, "--worktree", "filter.git-crypt.smudge", smudge); err != nil {
-		return err
-	}
-	if err := gitConfig(dir, "--worktree", "filter.git-crypt.clean", clean); err != nil {
-		return err
-	}
-	if err := gitConfig(dir, "--worktree", "filter.git-crypt.required", required); err != nil {
-		return err
-	}
-	return gitConfig(dir, "--worktree", "diff.git-crypt.textconv", "cat")
-}
-
-// UnsetFilterWorktree removes filter.git-crypt and diff.git-crypt sections
-// from the worktree-specific config.
-func UnsetFilterWorktree(dir string) error {
-	if err := EnableWorktreeConfig(dir); err != nil {
-		return fmt.Errorf("enabling worktree config: %w", err)
-	}
-	for _, section := range []string{"filter.git-crypt", "diff.git-crypt"} {
-		if err := gitConfig(dir, "--worktree", "--remove-section", section); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
-				continue
-			}
+	for _, section := range filterSections {
+		if err := gitConfig(dir, "--worktree", "filter."+section+".smudge", smudge); err != nil {
+			return err
+		}
+		if err := gitConfig(dir, "--worktree", "filter."+section+".clean", clean); err != nil {
+			return err
+		}
+		if err := gitConfig(dir, "--worktree", "filter."+section+".required", required); err != nil {
+			return err
+		}
+		if err := gitConfig(dir, "--worktree", "diff."+section+".textconv", "cat"); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// FilterConfigMatchesGitCrypt checks whether all four git-crypt filter/diff
-// config values match the expected encrypten values.
-func FilterConfigMatchesGitCrypt(dir string) (bool, error) {
-	checks := []struct {
-		key  string
-		want string
-	}{
-		{"filter.git-crypt.smudge", filterSmudge},
-		{"filter.git-crypt.clean", filterClean},
-		{"filter.git-crypt.required", filterReqd},
-		{"diff.git-crypt.textconv", diffTextconv},
+// UnsetFilterWorktree removes filter and diff sections for both git-crypt and
+// encrypten from the worktree-specific config.
+func UnsetFilterWorktree(dir string) error {
+	if err := EnableWorktreeConfig(dir); err != nil {
+		return fmt.Errorf("enabling worktree config: %w", err)
 	}
-	for _, c := range checks {
-		got, err := gitConfigGet(dir, c.key)
-		if err != nil {
-			return false, nil //nolint:nilerr // missing key means no match
+	for _, name := range filterSections {
+		for _, kind := range []string{"filter", "diff"} {
+			section := kind + "." + name
+			if err := gitConfig(dir, "--worktree", "--remove-section", section); err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 128 {
+					continue
+				}
+				return err
+			}
 		}
-		if got != c.want {
-			return false, nil
+	}
+	return nil
+}
+
+// FilterConfigured checks whether all filter/diff config values for both
+// git-crypt and encrypten sections match the expected encrypten values.
+func FilterConfigured(dir string) (bool, error) {
+	for _, section := range filterSections {
+		checks := []struct {
+			key  string
+			want string
+		}{
+			{"filter." + section + ".smudge", filterSmudge},
+			{"filter." + section + ".clean", filterClean},
+			{"filter." + section + ".required", filterReqd},
+			{"diff." + section + ".textconv", diffTextconv},
+		}
+		for _, c := range checks {
+			got, err := gitConfigGet(dir, c.key)
+			if err != nil {
+				return false, nil //nolint:nilerr // missing key means no match
+			}
+			if got != c.want {
+				return false, nil
+			}
 		}
 	}
 	return true, nil
+}
+
+// FilterConfigMatchesGitCrypt is an alias for FilterConfigured for backward compatibility.
+func FilterConfigMatchesGitCrypt(dir string) (bool, error) {
+	return FilterConfigured(dir)
 }

--- a/internal/gitutil/config_test.go
+++ b/internal/gitutil/config_test.go
@@ -27,14 +27,16 @@ func TestSetFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := configGet(t, dir, "filter.git-crypt.smudge"); got != "encrypten smudge" {
-		t.Errorf("smudge = %q, want %q", got, "encrypten smudge")
-	}
-	if got := configGet(t, dir, "filter.git-crypt.clean"); got != "encrypten clean" {
-		t.Errorf("clean = %q, want %q", got, "encrypten clean")
-	}
-	if got := configGet(t, dir, "filter.git-crypt.required"); got != "true" {
-		t.Errorf("required = %q, want %q", got, "true")
+	for _, section := range []string{"git-crypt", "encrypten"} {
+		if got := configGet(t, dir, "filter."+section+".smudge"); got != "encrypten smudge" {
+			t.Errorf("filter.%s.smudge = %q, want %q", section, got, "encrypten smudge")
+		}
+		if got := configGet(t, dir, "filter."+section+".clean"); got != "encrypten clean" {
+			t.Errorf("filter.%s.clean = %q, want %q", section, got, "encrypten clean")
+		}
+		if got := configGet(t, dir, "filter."+section+".required"); got != "true" {
+			t.Errorf("filter.%s.required = %q, want %q", section, got, "true")
+		}
 	}
 }
 
@@ -45,8 +47,10 @@ func TestSetDiffTextconv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := configGet(t, dir, "diff.git-crypt.textconv"); got != "encrypten diff" {
-		t.Errorf("textconv = %q, want %q", got, "encrypten diff")
+	for _, section := range []string{"git-crypt", "encrypten"} {
+		if got := configGet(t, dir, "diff."+section+".textconv"); got != "encrypten diff" {
+			t.Errorf("diff.%s.textconv = %q, want %q", section, got, "encrypten diff")
+		}
 	}
 }
 
@@ -70,6 +74,10 @@ func TestUnsetFilter(t *testing.T) {
 		"filter.git-crypt.clean",
 		"filter.git-crypt.required",
 		"diff.git-crypt.textconv",
+		"filter.encrypten.smudge",
+		"filter.encrypten.clean",
+		"filter.encrypten.required",
+		"diff.encrypten.textconv",
 	} {
 		cmd := exec.Command("git", "config", "--get", key) //nolint:gosec // test
 		cmd.Dir = dir
@@ -97,8 +105,10 @@ func TestSetFilterIdempotent(t *testing.T) {
 	}
 
 	// Values should still be correct.
-	if got := configGet(t, dir, "filter.git-crypt.smudge"); got != "encrypten smudge" {
-		t.Errorf("smudge = %q, want %q", got, "encrypten smudge")
+	for _, section := range []string{"git-crypt", "encrypten"} {
+		if got := configGet(t, dir, "filter."+section+".smudge"); got != "encrypten smudge" {
+			t.Errorf("filter.%s.smudge = %q, want %q", section, got, "encrypten smudge")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Recognize `filter=encrypten` and `filter=encrypten-<keyname>` in `.gitattributes` in addition to `filter=git-crypt` variants
- Register both `filter.encrypten.*` / `diff.encrypten.*` and `filter.git-crypt.*` / `diff.git-crypt.*` config sections for backward compatibility
- Add `FilterConfigured()` as the canonical check function, keeping `FilterConfigMatchesGitCrypt()` as a backward-compatible alias

Closes #1

## Test plan

- [x] `TestListEncryptedFilesEncryptenFilter` — `filter=encrypten` recognition
- [x] `TestListEncryptedFilesEncryptenNamedKey` — `filter=encrypten-mykey` recognition
- [x] `TestSetFilter` — verifies both `filter.git-crypt.*` and `filter.encrypten.*` are set
- [x] `TestSetDiffTextconv` — verifies both `diff.git-crypt.textconv` and `diff.encrypten.textconv`
- [x] `TestUnsetFilter` — verifies both sections are removed
- [x] All existing git-crypt compatibility tests still pass