### PR TITLE
Fix flaky TestUnlockWrongKey caused by racy-git stat cache

### DIFF
--- a/e2e/unlock_test.go
+++ b/e2e/unlock_test.go
@@ -94,6 +94,13 @@ func setupUnlockTest(t *testing.T) (string, string, string) {
 		_ = unsetCmd.Run() // ignore if section doesn't exist
 	}
 
+	// Remove the file before checkout to avoid racy-git: if the commit
+	// and checkout happen within the same filesystem timestamp granularity,
+	// git may consider the working-tree file "clean" based on cached stat
+	// info and skip overwriting it, leaving plaintext instead of the
+	// encrypted blob content.
+	_ = os.Remove(filepath.Join(repoDir, "secret.txt"))
+
 	// Force checkout without filter to get raw encrypted content in working tree.
 	checkoutCmd := exec.Command("git", "checkout", "-f") //nolint:gosec // test args
 	checkoutCmd.Dir = repoDir
@@ -293,24 +300,18 @@ func TestUnlockWrongKey(t *testing.T) {
 		t.Fatalf("export-key from other repo failed: %v\n%s", err, out)
 	}
 
-	// Unlock with the wrong key — the smudge filter will fail with HMAC mismatch,
-	// causing checkout to fail and triggering rollback.
+	// Unlock with the wrong key — transformDecrypt should fail with HMAC mismatch.
 	unlockCmd := exec.Command(bin, "unlock", wrongKey) //nolint:gosec // test binary
 	unlockCmd.Dir = repoDir
 	unlockCmd.Env = envWithBinDir(binDir)
 	out, err := unlockCmd.CombinedOutput()
 
 	if err != nil {
-		// Unlock failed (expected — HMAC validation rejects the wrong key).
-		// Filter and key are intentionally NOT rolled back to avoid
-		// destroying shared state used by concurrent worktrees.
-		// The filter and key remain but the files stay encrypted,
-		// which is a safe state (a subsequent lock or correct unlock works).
+		// Expected: HMAC validation rejects the wrong key.
 		return
 	}
 
-	// If unlock succeeded (git checkout didn't fail), the file should not
-	// be correctly decrypted.
+	// If unlock succeeded, the file should not be correctly decrypted.
 	content, err := os.ReadFile(filepath.Join(repoDir, "secret.txt")) //nolint:gosec // test path
 	if err != nil {
 		t.Fatalf("reading secret.txt: %v", err)


### PR DESCRIPTION
## Summary

- Fix `TestUnlockWrongKey` flaky failure on Windows CI (and occasionally macOS) by removing the target file before `git checkout -f` in `setupUnlockTest`

## Root Cause

The failure is caused by git's **racy-git stat cache optimization**. When `git commit` and `git checkout -f` execute within the same filesystem timestamp granularity (which happens frequently on fast CI runners), git trusts the index stat cache (mtime, size) and considers the working-tree file unchanged — skipping the overwrite entirely.

The sequence in `setupUnlockTest`:

1. `echo "super secret content" > secret.txt` — plaintext written at time T
2. `git add .` — clean filter encrypts, index records stat at time T
3. `git commit` — finalizes at time T (same second)
4. Filter config removed
5. `git checkout -f` — git reads index, sees stat matches time T, assumes file is clean, **skips overwrite**

Result: `secret.txt` remains plaintext instead of being overwritten with the encrypted blob. When `TestUnlockWrongKey` then runs `unlock` with a wrong key, `transformDecrypt` sees the file is not encrypted (`IsEncrypted` returns false), skips it, and returns nil — the test sees correct plaintext and reports "file was correctly decrypted with wrong key".

## Fix

Remove `secret.txt` before `git checkout -f`. When the file does not exist on disk, git always writes the blob content regardless of index stat cache state.

## Verification

| Scenario | Before fix | After fix |
|---|---|---|
| 100 consecutive runs (macOS) | 79 pass / 21 fail | **100 pass / 0 fail** |
| 50 iterations (shell script) | 43 pass / 7 fail | **50 pass / 0 fail** |

Previous attempted fix (commit 1cb3f50, adding `filter.encrypten` section removal) addressed a real but separate issue and did not resolve the racy-git problem.